### PR TITLE
Prevent the user from changing mutable Event object

### DIFF
--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -25,12 +25,7 @@ export interface StateUpdaterInput<TState, TCurrent> {
 // due to a state change. Reading through all the inbound events, and applying the rules creates
 // a materialised view. This view is the "STATE" record stored in the database.
 export class Event<T> {
-  type: string;
-  event: T | null;
-  constructor(type: string, event: T | null) {
-    this.type = type;
-    this.event = event;
-  }
+  constructor(readonly type: string, readonly event: T | null) {}
 }
 
 // RecordTypeName should be the name of the record's type, e.g. AccountDetails.


### PR DESCRIPTION
Changed the constructor to use the latest TS shorthand syntax.

Note: Commit from the IW Mail Order team. Michal Malinowski & @OAFCROB