### PR TITLE
start empty records from one

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -137,9 +137,9 @@ describe("facet", () => {
       facet.appendTo = async (id, state, seq): Promise<ChangeOutput<TestItem>> => {
         expect(id).toEqual("id");
         expect(state).toBe(null);
-        expect(seq).toEqual(1);
+        expect(seq).toEqual(0);
         return {
-          seq: 1,
+          seq: 0,
           item: {},
         } as ChangeOutput<TestItem>;
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export class Facet<T> {
   async append(id: string, ...newInboundEvents: Array<Event<any>>): Promise<ChangeOutput<T>> {
     const stateRecord = await this.get(id);
     const state = stateRecord ? stateRecord.item : null;
-    const seq = stateRecord ? stateRecord.record._seq : 1;
+    const seq = stateRecord ? stateRecord.record._seq : 0;
     return this.appendTo(id, state, seq, ...newInboundEvents);
   }
   // appendTo appends new events to an item that has already been retrieved from the

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -25,12 +25,7 @@ export interface StateUpdaterInput<TState, TCurrent> {
 // due to a state change. Reading through all the inbound events, and applying the rules creates
 // a materialised view. This view is the "STATE" record stored in the database.
 export class Event<T> {
-  type: string;
-  event: T | null;
-  constructor(type: string, event: T | null) {
-    this.type = type;
-    this.event = event;
-  }
+  constructor(readonly type: string, readonly event: T | null) {}
 }
 
 // RecordTypeName should be the name of the record's type, e.g. AccountDetails.


### PR DESCRIPTION
- Prevent the user from changing mutable Event object. Changed the constructor to use the latest TS shorthand syntax.
- Start new records with a sequence number of 1 in the case that the initial state is empty, not 2.
